### PR TITLE
Clean ROS1 dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ TAGS
 *.m~
 python/*.egg-info/
 /doc/_build/
+
+cmake-build-release/*
+cmake-build-debug/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Find required packages
-find_package(catkin REQUIRED COMPONENTS roscpp pcl_ros pcl_conversions sensor_msgs)
 find_package(PCL 1.8 REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(OpenMP QUIET)

--- a/include/utility.h
+++ b/include/utility.h
@@ -7,8 +7,6 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/filters/crop_box.h>
 #include <pcl/conversions.h>
-#include <pcl_ros/transforms.h>
-#include <pcl_conversions/pcl_conversions.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/common/centroid.h>
 #include <pcl/common/common.h>

--- a/src/BsplineSE3.cpp
+++ b/src/BsplineSE3.cpp
@@ -22,19 +22,7 @@
 #include "BsplineSE3.h"
 #include <vector>
 #include <Eigen/Dense>
-#include <fstream>
-#include <sstream>
-#include <iostream>
-#include <iomanip>
-#include <filesystem> // for directory reading
-#include <pcl_conversions/pcl_conversions.h>
-#include <pcl/io/pcd_io.h>
-#include <pcl/point_types.h>
-#include <pcl/filters/voxel_grid.h>
-#include <pcl/filters/crop_box.h>
-#include <string>
 #include <dirent.h>
-#include <algorithm>
 
 using namespace ov_core;
 


### PR DESCRIPTION
There were some dependencies in ROS1, so I removed those dependencies (29256d0)
(but not tested `helimos_saver`, `helimos_merger`, and `helimos_propagator`)
